### PR TITLE
Additional option entry for prefetched master tokens

### DIFF
--- a/custom_components/googlehome/config_flow.py
+++ b/custom_components/googlehome/config_flow.py
@@ -28,6 +28,14 @@ class GoogleHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         errors = {}
         if user_input is not None:
+            if user_input[CONF_MASTER_TOKEN]:
+                return self.async_create_entry(
+                    title=user_input[CONF_USERNAME],
+                    data={
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_MASTER_TOKEN: user_input[CONF_MASTER_TOKEN],
+                    },
+                )
             mt = await self.hass.async_add_executor_job(
                 get_master_token, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             )
@@ -45,6 +53,7 @@ class GoogleHomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         data_schema = OrderedDict()
         data_schema[vol.Required(CONF_USERNAME)] = str
         data_schema[vol.Required(CONF_PASSWORD)] = str
+        data_schema[vol.Optional(CONF_MASTER_TOKEN)] = str
 
         return self.async_show_form(
             step_id="user", data_schema=vol.Schema(data_schema), errors=errors

--- a/custom_components/googlehome/strings.json
+++ b/custom_components/googlehome/strings.json
@@ -3,16 +3,17 @@
     "step": {
       "user": {
         "title": "Login to Google",
-        "description": "Please provide login credentials to a linked google account of your google home and nest devices. If you are using 2-factor authentication, you need to use an application password. You may delete the application password once the integration is sucessfully setup.",
+        "description": "Please provide login credentials to a linked google account of your google home and nest devices. If you are using 2-factor authentication, you need to use an application password. You may delete the application password once the integration is sucessfully setup. If you encounter a problem with the login, you can also provide a self-fetched master token in the appropriate field (this field can be left empty if the username and password combination is working for you).",
         "data": {
           "username": "Google Account",
           "password": "Password",
-          "master_token": "Master Token"
+          "master_token": "Master Token (Optional)"
         }
       }
     },
     "error": {
-      "auth_error": "Login failed"
+      "auth_error": "Login failed",
+      "master_token_incorrect": "Incorrect master token"
     }
   },
   "options": {

--- a/custom_components/googlehome/strings.json
+++ b/custom_components/googlehome/strings.json
@@ -6,7 +6,8 @@
         "description": "Please provide login credentials to a linked google account of your google home and nest devices. If you are using 2-factor authentication, you need to use an application password. You may delete the application password once the integration is sucessfully setup.",
         "data": {
           "username": "Google Account",
-          "password": "Password"
+          "password": "Password",
+          "master_token": "Master Token"
         }
       }
     },

--- a/custom_components/googlehome/translations/de.json
+++ b/custom_components/googlehome/translations/de.json
@@ -5,8 +5,9 @@
         "title": "Bei Google anmelden",
         "description": "Bitte gebe deine Logindaten zu einem mit deinen Google Home oder Google Nest Geräten verknüpften Google Account ein. Wenn du 2-factor-Authentifizierung nutzt, brauchst du ein Application Password. Dieses kann nach erfolgreicher Einrichtung der Integration wieder gelöscht werden.",
         "data": {
-          "username": "Google Account",
-          "password": "Passwort"
+          "username": "Google Konto",
+          "password": "Passwort",
+          "master_token": "Master Token"
         }
       }
     },

--- a/custom_components/googlehome/translations/de.json
+++ b/custom_components/googlehome/translations/de.json
@@ -3,16 +3,17 @@
     "step": {
       "user": {
         "title": "Bei Google anmelden",
-        "description": "Bitte gebe deine Logindaten zu einem mit deinen Google Home oder Google Nest Geräten verknüpften Google Account ein. Wenn du 2-factor-Authentifizierung nutzt, brauchst du ein Application Password. Dieses kann nach erfolgreicher Einrichtung der Integration wieder gelöscht werden.",
+        "description": "Bitte gebe deine Logindaten zu einem mit deinen Google Home oder Google Nest Geräten verknüpften Google Account ein. Wenn du 2-factor-Authentifizierung nutzt, brauchst du ein Application Password. Dieses kann nach erfolgreicher Einrichtung der Integration wieder gelöscht werden. Falls Probleme auftauchen sollte während des Loginprozesses, kann auch ein vorhandener Mastertoken in das vorgesehene Feld hinterlegt werden (dies ist nicht nötig, falls die Benutzername und Passwort Kombination funktioniert).",
         "data": {
           "username": "Google Konto",
           "password": "Passwort",
-          "master_token": "Master Token"
+          "master_token": "Master Token (Optional)"
         }
       }
     },
     "error": {
-      "auth_error": "Login fehlgeschlagen"
+      "auth_error": "Login fehlgeschlagen",
+      "master_token_incorrect": "Fehlerhafter Mastertoken"
     }
   },
   "options": {

--- a/custom_components/googlehome/translations/en.json
+++ b/custom_components/googlehome/translations/en.json
@@ -3,16 +3,17 @@
     "step": {
       "user": {
         "title": "Login to Google",
-        "description": "Please provide login credentials to a linked google account of your google home and nest devices. If you are using 2-factor authentication, you need to use an application password. You may delete the application password once the integration is sucessfully setup.",
+        "description": "Please provide login credentials to a linked google account of your google home and nest devices. If you are using 2-factor authentication, you need to use an application password. You may delete the application password once the integration is sucessfully setup. If you encounter a problem with the login, you can also provide a self-fetched master token in the appropriate field (this field can be left empty if the username and password combination is working for you).",
         "data": {
           "username": "Google Account",
           "password": "Password",
-          "master_token": "Master Token"
+          "master_token": "Master Token (Optional)"
         }
       }
     },
     "error": {
-      "auth_error": "Login failed"
+      "auth_error": "Login failed",
+      "master_token_incorrect": "Incorrect master token"
     }
   },
   "options": {

--- a/custom_components/googlehome/translations/en.json
+++ b/custom_components/googlehome/translations/en.json
@@ -6,7 +6,8 @@
         "description": "Please provide login credentials to a linked google account of your google home and nest devices. If you are using 2-factor authentication, you need to use an application password. You may delete the application password once the integration is sucessfully setup.",
         "data": {
           "username": "Google Account",
-          "password": "Password"
+          "password": "Password",
+          "master_token": "Master Token"
         }
       }
     },


### PR DESCRIPTION
Bypass the retrieval of the master token by providing it at the setup process.
The password field is still required, but is not actively used afterwards.